### PR TITLE
add: 添加了大代码包部署的实践指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@
 - [使用s工具安装字体.md](/docs/使用s工具安装字体.md)
 
 - [PHP Runtime 出错信息有 FastCGI](/docs/php-fastcgi.md)
+
+- [大代码包部署的实践案例](/docs/大代码包部署的实践案例.md)

--- a/docs/大代码包部署的实践案例.md
+++ b/docs/大代码包部署的实践案例.md
@@ -14,7 +14,7 @@
 1. 进入[阿里云oss控制台](https://oss.console.aliyun.com/)，创建bucket。如无特殊需求，bucket可按默认配置创建。
 2. 在s.yaml文件中，相应的服务下配置ossBucket字段，值为你想使用的bucket名称。
 
-s配置文件示例如下：
+s.yaml配置如下：
 ```
 edition: 1.0.0          #  命令行YAML规范版本，遵循语义化版本（Semantic Versioning）规范
 name: fcDeployApp       #  项目名称
@@ -120,19 +120,21 @@ fc-deploy-test:
       fcDir: /mnt/auto
 ```
 
-> nas是fc组件提供的与文件存储服务相关的指令，你可以执行`s fc-deploy-test nas -h`来查看具体的副指令信息。
+> nas是fc组件提供的与文件存储服务相关的指令，你可以执行`s fc-deploy-test nas -h`来查看具体的副指令信息。或者查看[硬盘挂载操作文档](https://github.com/devsapp/fc/blob/main/docs/Usage/nas.md)。
 
 #### 2.1.2 上传大文件
 
-在有s.yaml文件的目录下，执行`s fc-deploy-test nas upload -r code/node_modules nas:///mnt/auto`指令。其中`fc-deploy-test`是你的服务名称，nas是由fc组件提供的指令，upload表示上，-r参数表示递归地处理目标路径下的文件夹，最后的路径是在上一步中生成的存储路径，以auto方式生成的固定为`/mnt/auto`。
+在s.yaml文件所在的目录下，执行`s fc-deploy-test nas upload -r code/node_modules nas:///mnt/auto`指令。其中`fc-deploy-test`是你的Serverless Devs项目名称，nas是由fc组件提供的指令，upload表示上传，-r参数表示递归地处理目标路径下的文件夹，最后的路径是在上一步中生成的存储路径，以auto方式生成的固定为`/mnt/auto`。
+
+随后，可以通过`s nas command ls -al /mnt/auto`或`s exec -- nas command ls -al /mnt/auto`命令查看目录。
 
 #### 2.1.3 修改配置
 
 完成了大文件的传输之后，我们需要在部署的过程中忽略该大文件，还需要在这种情况下告诉系统那些文件的路径，这就需要配置环境变量。
 
-首先，类似`.gitignore`，fc组件会根据`.fcignore`忽略其中的文件。对于这个例子而言，我们只要写入一个`node_modules`就可以了。
+首先，类似`.gitignore`，fc组件会根据`.fcignore`忽略其中的文件。对于这个例子而言，我们只要写入一个`code/node_modules`就可以了。
 
-在本例中，我们上传的是nodejs环境的依赖包，所以需要在function中添加environmentVariables字段，在其子字段中添加`NODE_PATH: /mnt/auto/node_modules`键值对。如下所示：
+在本例中，我们上传的是nodejs环境的依赖包，所以需要在function中添加`environmentVariables`字段，在其子字段中添加`NODE_PATH: /mnt/auto/node_modules`键值对。如下所示：
 
 ```
 function:
@@ -140,8 +142,6 @@ function:
   description: this is a test
   runtime: nodejs12
   codeUri: ./code
-  # ossBucket:
-  # ossKey:  # conflict with codeUri
   handler: index.handler
   memorySize: 128
   timeout: 60
@@ -153,12 +153,268 @@ function:
 
 #### 2.1.4 部署函数
 
-目前，所有的准备工作都已完成，只需要使用`s deploy`指令将你的函数部署即可。
+目前，所有的准备工作都已完成，只需要在s.yaml目录下使用`s deploy`指令将你的函数部署即可。
+
+### 2.2 使用函数计算的layer
+
+函数计算中的层提供自定义的公共依赖库、运行时环境及函数扩展等发布与部署能力。关于层的更多介绍，参考[层介绍文档](https://help.aliyun.com/document_detail/193057.html?spm=5176.8663048.help.dexternal.4ef03edceVGj18)。所以，我们也可以利用它来存放大资源。
+
+> ⚠️ 需要注意，每个函数只能创建5个层，每个层的容量限制为50M。所以，使用层，对数据的大小有限制，并且还需要对数据进行一定的分割。根据你的项目情况，判断是否适合使用这个方法。
+
+假设我们现在有如下结构的项目：
+```
+--project
+  |--s.yaml
+  |--.fcignore
+  |--code
+     |--node_modules
+     |--index.js
+     |--package.json
+     |--package-lock.json
+     |--data
+        |--20210818/  (48M)
+        |--temp2/     (49M)
+```
+
+利用层来进行大代码包的部署简单分为以下三步：
+1. 创建层
+2. 获取层的配置并写入s.yaml
+3. 部署函数
+
+#### 2.2.1 创建层
+
+fc组件下提供了layer指令来提供与层相关的操作，详细说明可以参考文档[层的操作](https://github.com/devsapp/fc/blob/main/docs/Usage/layer.md)。根据本例中的项目结构，在这一步，使用layer publish指令，创建两个层，具体操作如下：
+
+```
+[xxx@xxx]s fc-deploy-test layer publish --layer-name data-20210818 --code ./code/data/20210818 --region cn-hangzhou
+......
+[xxx@xxx]s fc-deploy-test layer publish --layer-name data-temp2 --code ./code/data/temp2 --region cn-hangzhou
+......
+```
+
+其中，必填的参数有`--layer-name`、`--code`以及`--region`。`--layer-name`指定该层的名称，`--code`指定上传数据的相对s.yaml的路径，`--region`指定该层创建的地区。
+
+#### 2.2.2 获取层配置并写入s.yaml
+
+创建完成后会返回层的一些配置信息，或者使用`layer versionConfig`指令来获取指定层的配置信息。在本例中，具体操作如下：
+
+```
+[xxx@xxx]s layer versionConfig --layer-name data-20210818 --version-id 1
+...
+fc-deploy-test:
+  layerName: data-20210818
+  version: 1
+  ...
+  ...
+  arn: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+其中要用到的只有arn，粘贴到s.yaml的function的layers子字段下即可。本例中，s.yaml配置如下：
+
+```
+function:
+  name: event-function
+  description: this is a test
+  runtime: nodejs12
+  codeUri: ./code
+  handler: index.handler
+  memorySize: 128
+  timeout: 60
+  layers:
+  - xxxxxxxxxxxxxxxxxxxxxxxx#data-20210818#1
+  - xxxxxxxxxxxxxxxxxxxxxxxx#data-temp2#1
+```
+
+需要注意的是，层默认部署在函数执行环境的`/opt`目录下。所以，如果上传的是环境的依赖库，例如node_modules，需要在s.yaml中的function字段下配置环境变量，如下所示：
+```
+environmentVariables:
+  NODE_PATH: /opt
+```
+
+随后，在.fcignore中添加`code/data`将大数据包忽略。
+
+### 2.2.2 部署函数
+
+在s.yaml所在的目录下，通过`s deploy`指令即可完成部署。
+
+### 2.3 将函数转换成custom-container
+
+最后一种方法，使用自定义容器运行环境，将函数构建成镜像发布到阿里云镜像仓库中，通过HTTP协议和函数计算系统交互。更多详细介绍可参考文档[Custom Container简介](https://help.aliyun.com/document_detail/179368.html)。使用这种方法，需要开通[阿里云容器镜像服务](https://cr.console.aliyun.com/)。
+
+> ⚠️ 需要注意，该方法也存在使用限制：若您的函数执行内存小于1 GB，则解压前镜像大小不能超过256 MB；若您的函数执行内存不小于1 GB，则解压前镜像大小不能超过1024 MB。
+
+如果你有容器相关的知识，可以根据自己的项目进行改造，自行编写Dockerfile，再执行后续操作；如果没有的话也没关系，[函数计算custom-container入门示例](https://github.com/awesome-fc/fc-faq/blob/main/docs/%E5%87%BD%E6%95%B0%E8%AE%A1%E7%AE%97custom%E5%92%8Ccustom-container%E5%85%A5%E9%97%A8%E7%A4%BA%E4%BE%8B.md)中展示了一些s工具提供的初始化模板，另外，[fc组件-自定义容器示例](https://github.com/devsapp/fc/tree/main/examples/custom-container-function)也提供了一个小型的示例。接下来，根据以上两个链接中的内容，以部署一个nodejs运行环境的http应用为例进行详细说明。
+
+1. 初始化（改造）项目
+2. 配置s.yaml
+3. 本地环境变量和bash脚本
+4. 部署项目
+
+#### 2.3.1 初始化（改造）项目
+
+关于项目的初始化或者改造部分，在本例中，最关键的点有两个：容器中运行的http服务，以及构建镜像的Dockerfile。
+
+首先，通过`s init start-fc-custom-container-event-nodejs14 -d start-cc-nodejs14`命令，可以初始化该项目。该生成的项目结构如下：
+
+```
+--start-cc-nodejs14
+  |--s.yaml
+  |--README.md
+  |--code
+     |--Dockerfile
+     |--package.json
+     |--server.js
+```
+
+和之前的例子一样，code目录下是我们的源代码，之后需要整个构建成镜像，以容器形式运行。所以本例中的server.js就是一个http服务脚本，内容如下：
+
+```
+'use strict';
+
+const express = require('express');
+
+// Constants
+const PORT = 8080;
+const HOST = '0.0.0.0';
+
+// HTTP function invocation
+const app = express();
+app.get('/*', (req, res) => {
+  res.send('Hello FunctionCompute, http function\n');
+});
+
+// Event function invocation
+app.post('/invoke', (req, res) => {
+  res.send('Hello FunctionCompute, event function\n');
+});
+
+var server = app.listen(PORT, HOST);
+console.log(`Running on http://${HOST}:${PORT}`);
+
+server.timeout = 0; // never timeout
+server.keepAliveTimeout = 0; // keepalive, never timeout
+```
+
+不同于之前的例子，因为整个脚本将直接运行在容器内，所以它没有导出一个express实例，这一点也将体现在s.yaml上。
+
+随后，我们来看看自动生成的Dockerfile做了什么。其内容如下：
+
+```
+FROM node:14.5.0-alpine3.11
+
+# Create app directory
+WORKDIR /usr/src/
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY ./package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+EXPOSE 8080
+ENTRYPOINT [ "node", "server.js" ]
+```
+
+该文件选定基础镜像，设定工作目录，打包并安装依赖和项目目录下的所有资源，最后暴露端口，设定启动程序。其中的具体指令可以参考Docker相关文档，在此不多做赘述。
+
+在明确了以上最重要的两个部分之后，就可以根据自己的需求，改造该项目的结构或者放入更多的数据资源。它就会成为一个大的代码包，但不要忘记本节开头提到的镜像大小限制。
+
+#### 2.3.2 配置s.yaml
+
+本例中完整的的s.yaml配置如下：
+```
+edition: 1.0.0
+name: container-demo
+access: default
+vars:
+  region: cn-hangzhou
+services:
+  customContainer-demo:
+    component: devsapp/fc
+    props:
+      region: ${vars.region}
+      service:
+        name: container-demo
+        internetAccess: true
+      function:
+        name: nodejs14-event-function
+        description: custom container test function
+        caPort: 8080
+        memorySize: 256
+        timeout: 60
+        runtime: custom-container
+        customContainerConfig:
+          image: ${env(image)}}
+          command: '["node"]'
+          args: '["server.js"]'
+        codeUri: ./code
+      triggers:
+        - name: httpTrigger
+          type: http
+          config:
+            authType: anonymous
+            methods:
+              - GET
+              - POST
+              - PUT
+      customDomains:
+        - domainName: auto
+          protocol: HTTP
+          routeConfigs:
+            - path: /*
+              serviceName: container-demo
+              functionName: nodejs14-event-function
+
+```
+
+可以发现其几乎和之前的例子没有多大差别，但仍要注意：因为是自定义容器环境，所以不再需要handler，取而代之的是`customContainerConfig`字段，其中三个子字段分别代表选用的镜像，容器中执行的命令，以及参数。这里的镜像使用了自己创建的本地环境变量。这是为了简化之后的一系列操作。
+
+#### 2.3.3 本地环境变量和bash脚本
+
+因为在多个命令中需要频繁用到诸如image的变量，我们可在s.yaml所在的目录下，创建一个.env环境变量文件来同一管理，更方便调试。本例中的.env内容如下：
+
+```
+export AccessKeyID=yourAccessKeyID
+export AccessKeySecret=yourAccessKeySecret
+export AccountID=AccountID
+export aliasName=default
+export image=xxx  # 格式： ${registry}/${repository}/${imageName}:${imageTag}
+```
+
+如果你不是第一次使用s工具，那么前四个变量没有必要。关键在于最后这个image的名称，**需要特别注意**，`${registry}`的部分一定要填`registry.cn-hangzhou.aliyuncs.com`（其中的cn-hangzhou可以换成你所需的地区），因为阿里云的镜像仓库只接收ACR镜像。
+
+随后，我们在同样的目录下添加一个setup.sh脚本，方便管理接下来的操作。其内容如下：
+
+```
+set -e
+
+source ./.env
+
+#s config add --AccessKeyID "$AccessKeyID" --AccessKeySecret "$AccessKeySecret" --AccountID "$AccountID" --aliasName "$aliasName"
+
+sudo -E s build --use-docker -f ./code/Dockerfile
+
+sudo -E s deploy --push-registry acr-internet  --use-local -y
+```
+
+其中`s config`命令若不是第一次使用s工具部署，可以注释掉。特别注意后两条命令，若Linux系统有权限限制，则必须使用sudo权限，添加-E参数，表示保留刚才读入的环境变量。
+
+其中`s build --use-docker -f ./code/Dockerfile`利用docker命令和目标Dockerfile来进行镜像的构建，所以前提是必须要安装docker。关于docker的内容再次不多赘述，可查阅官网。`s deploy --push-registry acr-internet --use-local -y`会将构建好的镜像推到阿里云镜像仓库，然后利用它来进行部署。
+
+#### 2.3.4 部署项目
+
+执行`setup.sh`脚本，系统会依次执行里面的指令，如无意外，最终会输出部署好的项目信息。
 
 ## 3 更多实践案例
 
-- [猫狗分类](https://github.com/awesome-fc/cat-dog-classify)
-- [情绪识别](https://developer.aliyun.com/article/785367)
+- [利用Nas系统-猫狗分类](https://github.com/awesome-fc/cat-dog-classify)
+- [利用Nas系统-情绪识别](https://developer.aliyun.com/article/785367)
 
 
 

--- a/docs/大代码包部署的实践案例.md
+++ b/docs/大代码包部署的实践案例.md
@@ -157,11 +157,11 @@ function:
 
 ### 2.2 使用函数计算的layer
 
-函数计算中的层提供自定义的公共依赖库、运行时环境及函数扩展等发布与部署能力。关于层的更多介绍，参考[层介绍文档](https://help.aliyun.com/document_detail/193057.html?spm=5176.8663048.help.dexternal.4ef03edceVGj18)。所以，我们也可以利用它来存放大资源。
+函数计算中的层提供自定义的公共依赖库、运行时环境及函数扩展等发布与部署能力。关于层的更多介绍，参考[层介绍文档](https://help.aliyun.com/document_detail/193057.html)。所以，我们也可以利用它来存放大资源。
 
 接下来的操作示例以两个数据包为例，主要体现的是容量上的特点。实际上，层更推荐用来存放公共依赖，例如node_modules，每次部署项目只要引入所需的层即可。而较大的数据集推荐放在Nas文件系统中，又或者是使用自定义容器的方法。
 
-> ⚠️ 需要注意，每个函数只能创建5个层，每个层的容量限制为50M。所以，使用层，对数据的大小有限制，并且还需要对数据进行一定的分割。根据你的项目情况，判断是否适合使用这个方法。
+> ⚠️ 需要注意，每个函数只能创建5个层，每个层的容量限制为压缩前50M。所以，使用层，对数据的大小有限制，并且还需要对数据进行一定的分割。根据你的项目情况，判断是否适合使用这个方法。
 
 假设我们现在有如下结构的项目：
 ```
@@ -189,9 +189,17 @@ fc组件下提供了layer指令来提供与层相关的操作，详细说明可�
 
 ```
 [xxx@xxx]s fc-deploy-test layer publish --layer-name data-20210818 --code ./code/data/20210818 --region cn-hangzhou
-......
+[2021-09-14T20:55:19.391] [INFO ] [S-CLI] - Start ...
+Packing ...
+Package complete.
+[2021-09-14T20:55:23.659] [INFO ] [] - Creating layer: layer-test
+fc-deploy-test: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#data-20210818#1
 [xxx@xxx]s fc-deploy-test layer publish --layer-name data-temp2 --code ./code/data/temp2 --region cn-hangzhou
-......
+[2021-09-14T20:55:19.391] [INFO ] [S-CLI] - Start ...
+Packing ...
+Package complete.
+[2021-09-14T20:55:23.659] [INFO ] [] - Creating layer: data-temp2
+fc-deploy-test: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx#data-temp2#1
 ```
 
 其中，必填的参数有`--layer-name`、`--code`以及`--region`。`--layer-name`指定该层的名称，`--code`指定上传数据的相对s.yaml的路径，`--region`指定该层创建的地区。
@@ -227,10 +235,12 @@ function:
   - xxxxxxxxxxxxxxxxxxxxxxxx#data-temp2#1
 ```
 
-需要注意的是，层默认部署在函数执行环境的`/opt`目录下。所以，如果上传的是环境的依赖库，例如node_modules，需要在s.yaml中的function字段下配置环境变量，如下所示：
+需要注意的是，层默认部署在函数执行环境的`/opt`目录下。所以，如果上传的是环境的依赖库，例如node_modules，需要在s.yaml中的function字段下配置环境变量，如下所示，提供了nodejs、python以及可执行二进制文件（bin）对应的环境变量示例：
 ```
 environmentVariables:
   NODE_PATH: /opt
+  PYTHONUSERBASE: /opt
+  PATH: /opt
 ```
 
 随后，在.fcignore中添加`code/data`将大数据包忽略。

--- a/docs/大代码包部署的实践案例.md
+++ b/docs/大代码包部署的实践案例.md
@@ -233,7 +233,7 @@ environmentVariables:
 
 随后，在.fcignore中添加`code/data`将大数据包忽略。
 
-### 2.2.2 部署函数
+#### 2.2.3 部署函数
 
 在s.yaml所在的目录下，通过`s deploy`指令即可完成部署。
 

--- a/docs/大代码包部署的实践案例.md
+++ b/docs/大代码包部署的实践案例.md
@@ -149,7 +149,7 @@ function:
     NODE_PATH: /mnt/auto/node_modules
 ```
 
-对于不同的项目，使用到的环境变量名称各不相同。比如，对于python解释器而言，它是通过PYTHONPATH这个环境变量来查找模块的，所以就应该在环境变量中添加`PYTHONUSERBASE: /yourpath`。
+对于不同的项目，使用到的环境变量名称各不相同。比如，对于python解释器而言，它是通过PYTHONUSERBASE这个环境变量来查找模块的，所以就应该在环境变量中添加`PYTHONUSERBASE: /yourpath`。
 
 #### 2.1.4 部署函数
 

--- a/docs/大代码包部署的实践案例.md
+++ b/docs/大代码包部署的实践案例.md
@@ -1,0 +1,165 @@
+使用fc组件进行部署对于压缩后的代码包大小有限制。不超过50M的情况下，默认的s.yaml配置文件就足以应对。对于超过50M的不同大小范围，要进行不同的应对方式。
+
+
+## 1 代码包大于50M小于等于100M
+
+此时使用默认配置进行部署，会有如下报错提示：
+
+![](https://raykie.top/img/%2850%2C100%5Dcase.png)
+
+基本应对思路是使用阿里云oss对象存储服务，创建一个用于用于存放代码包的bucket，随后在s.yaml文件中配置ossBucket字段，即可进行部署。
+
+步骤如下：
+
+1. 进入[阿里云oss控制台](https://oss.console.aliyun.com/)，创建bucket。如无特殊需求，bucket可按默认配置创建。
+2. 在s.yaml文件中，相应的服务下配置ossBucket字段，值为你想使用的bucket名称。
+
+s配置文件示例如下：
+```
+edition: 1.0.0          #  命令行YAML规范版本，遵循语义化版本（Semantic Versioning）规范
+name: fcDeployApp       #  项目名称
+access: "default"  #  秘钥别名
+
+services:
+  fc-deploy-test: #  服务名称
+    component: devsapp/fc  # 组件名称
+    props: #  组件的属性值
+      region: cn-hangzhou
+      service:
+        name: fc-deploy-service
+        description: 'demo for fc-deploy component'
+        internetAccess: true
+      function:
+        name: http-trigger-function
+        description: this is a test
+        runtime: nodejs12
+        codeUri: ./code
+        ossBucket: your-bucket-name # 填写你想使用的bucket的名称
+        # ossKey:  # conflict with codeUri
+        handler: index.handler
+        memorySize: 128
+        timeout: 60
+      triggers:
+        - name: httpTrigger
+          type: http
+          config:
+            authType: anonymous
+            methods:
+              - GET
+      customDomains:
+        - domainName: auto
+          protocol: HTTP
+          routeConfigs:
+            - path: /*
+              methods:
+                - GET
+# 函数计算FC组件文档参考地址：https://github.com/devsapp/fc
+```
+
+执行`s deploy`部署成功以后，我们可以直接在函数计算控制台>服务及函数>点击该函数名称>代码执行中，看到我们的代码包已经完整地部署成功了。
+
+![](https://raykie.top/img/40-100%E6%88%90%E5%8A%9F.png)
+
+
+## 2 代码包大于100M
+
+当压缩后的代码包大于100M时，有三种策略用以部署：使用Nas文件系统辅助存储、使用函数计算的层（Layer）、将函数转换成custom-container（需要对代码进行一定的改造）。
+
+### 2.1 使用NAS文件系统辅助存储
+
+对于一个大代码包，其占用空间较多的一般是依赖包（比如node_modules）或者静态数据资源（比如训练集、数据包）。所以，我们可以使用NAS文件系统来存储这些占用大多数空间的数据，之后配合一个简单的.fcignore文件，就能把剩余的部分部署到函数计算。
+
+步骤大致分为3步：
+
+1. 初始化文件系统
+2. 上传大文件
+3. 修改配置
+4. 部署函数
+
+#### 2.1.1 初始化文件系统
+
+要使用NAS文件系统，首先需要在阿里云[文件存储控制台](https://nasnext.console.aliyun.com/)开通这项服务。随后，可以手动在控制台创建文件系统，也可以在本地利用s工具自动创建。接下来的流程介绍在本地利用s工具自动初始化。
+
+假设现有一个http应用，结构如下：
+
+```
+--project
+  |--s.yaml
+  |--.fcignore
+  |--code
+     |--node_modules
+     |--index.js
+     |--package.json
+     |--package-lock.json
+```
+
+首先，在s.yaml文件对应的服务下，找到service字段，在其中添加一个`nasConfig: auto`键值对。
+
+```
+services:
+  fc-deploy-test: #  服务名称
+    component: devsapp/fc  # 组件名称
+    props: #  组件的属性值
+      region: cn-hangzhou
+      service:
+        name: fc-deploy-service
+        description: 'demo for fc-deploy component'
+        nasConfig: auto
+        internetAccess: true
+```
+
+随后，在有s.yaml文件的目录下，执行`s fc-deploy-test nas init`指令，根据你配置的auto属性，fc组件会帮你执行一系列流程创建一个文件系统。最后终端会输出生成的文件系统的基本信息：
+
+```
+fc-deploy-test:
+  userId: 10003
+  groupId: 10003
+  mountPoints:
+    - serverAddr: xxxxxxxxxxxxx.cn-hangzhou.nas.aliyuncs.com
+      nasDir: /fc-deploy-service
+      fcDir: /mnt/auto
+```
+
+> nas是fc组件提供的与文件存储服务相关的指令，你可以执行`s fc-deploy-test nas -h`来查看具体的副指令信息。
+
+#### 2.1.2 上传大文件
+
+在有s.yaml文件的目录下，执行`s fc-deploy-test nas upload -r code/node_modules nas:///mnt/auto`指令。其中`fc-deploy-test`是你的服务名称，nas是由fc组件提供的指令，upload表示上，-r参数表示递归地处理目标路径下的文件夹，最后的路径是在上一步中生成的存储路径，以auto方式生成的固定为`/mnt/auto`。
+
+#### 2.1.3 修改配置
+
+完成了大文件的传输之后，我们需要在部署的过程中忽略该大文件，还需要在这种情况下告诉系统那些文件的路径，这就需要配置环境变量。
+
+首先，类似`.gitignore`，fc组件会根据`.fcignore`忽略其中的文件。对于这个例子而言，我们只要写入一个`node_modules`就可以了。
+
+在本例中，我们上传的是nodejs环境的依赖包，所以需要在function中添加environmentVariables字段，在其子字段中添加`NODE_PATH: /mnt/auto/node_modules`键值对。如下所示：
+
+```
+function:
+  name: http-trigger-function
+  description: this is a test
+  runtime: nodejs12
+  codeUri: ./code
+  # ossBucket:
+  # ossKey:  # conflict with codeUri
+  handler: index.handler
+  memorySize: 128
+  timeout: 60
+  environmentVariables:
+    NODE_PATH: /mnt/auto/node_modules
+```
+
+对于不同的项目，使用到的环境变量名称各不相同。比如，对于python解释器而言，它是通过PYTHONPATH这个环境变量来查找模块的，所以就应该在环境变量中添加`PYTHONPATH: /yourpath`。
+
+#### 2.1.4 部署函数
+
+目前，所有的准备工作都已完成，只需要使用`s deploy`指令将你的函数部署即可。
+
+## 3 更多实践案例
+
+- [猫狗分类](https://github.com/awesome-fc/cat-dog-classify)
+- [情绪识别](https://developer.aliyun.com/article/785367)
+
+
+
+

--- a/docs/大代码包部署的实践案例.md
+++ b/docs/大代码包部署的实践案例.md
@@ -1,4 +1,4 @@
-使用fc组件进行部署对于压缩后的代码包大小有限制。不超过50M的情况下，默认的s.yaml配置文件就足以应对。对于超过50M的不同大小范围，要进行不同的应对方式。
+使用fc组件进行部署对于压缩后的代码包大小有限制。不超过50M的情况下，默认的s.yaml配置文件就足以应对。对于超过50M的不同大小范围，以及项目特点，要进行不同的应对方式。
 
 
 ## 1 代码包大于50M小于等于100M
@@ -407,7 +407,7 @@ sudo -E s deploy --push-registry acr-internet  --use-local -y
 
 其中`s config`命令若不是第一次使用s工具部署，可以注释掉。特别注意后两条命令，若Linux系统有权限限制，则必须使用sudo权限，添加-E参数，表示保留刚才读入的环境变量。
 
-其中`s build --use-docker -f ./code/Dockerfile`利用docker命令和目标Dockerfile来进行镜像的构建，所以前提是必须要安装docker。关于docker的内容再次不多赘述，可查阅官网。`s deploy --push-registry acr-internet --use-local -y`会将构建好的镜像推到阿里云镜像仓库，然后利用它来进行部署。
+其中`s build --use-docker -f ./code/Dockerfile`利用docker命令和目标Dockerfile来进行镜像的构建，所以前提是必须要安装docker。关于docker的内容在此不多赘述，可查阅官网。`s deploy --push-registry acr-internet --use-local -y`会将构建好的镜像推到阿里云镜像仓库，然后利用它来进行部署。
 
 #### 2.3.4 部署项目
 
@@ -417,7 +417,3 @@ sudo -E s deploy --push-registry acr-internet  --use-local -y
 
 - [利用Nas系统-猫狗分类](https://github.com/awesome-fc/cat-dog-classify)
 - [利用Nas系统-情绪识别](https://developer.aliyun.com/article/785367)
-
-
-
-

--- a/docs/大代码包部署的实践案例.md
+++ b/docs/大代码包部署的实践案例.md
@@ -149,7 +149,7 @@ function:
     NODE_PATH: /mnt/auto/node_modules
 ```
 
-对于不同的项目，使用到的环境变量名称各不相同。比如，对于python解释器而言，它是通过PYTHONPATH这个环境变量来查找模块的，所以就应该在环境变量中添加`PYTHONPATH: /yourpath`。
+对于不同的项目，使用到的环境变量名称各不相同。比如，对于python解释器而言，它是通过PYTHONPATH这个环境变量来查找模块的，所以就应该在环境变量中添加`PYTHONUSERBASE: /yourpath`。
 
 #### 2.1.4 部署函数
 
@@ -158,6 +158,8 @@ function:
 ### 2.2 使用函数计算的layer
 
 函数计算中的层提供自定义的公共依赖库、运行时环境及函数扩展等发布与部署能力。关于层的更多介绍，参考[层介绍文档](https://help.aliyun.com/document_detail/193057.html?spm=5176.8663048.help.dexternal.4ef03edceVGj18)。所以，我们也可以利用它来存放大资源。
+
+接下来的操作示例以两个数据包为例，主要体现的是容量上的特点。实际上，层更推荐用来存放公共依赖，例如node_modules，每次部署项目只要引入所需的层即可。而较大的数据集推荐放在Nas文件系统中，又或者是使用自定义容器的方法。
 
 > ⚠️ 需要注意，每个函数只能创建5个层，每个层的容量限制为50M。所以，使用层，对数据的大小有限制，并且还需要对数据进行一定的分割。根据你的项目情况，判断是否适合使用这个方法。
 
@@ -241,7 +243,7 @@ environmentVariables:
 
 最后一种方法，使用自定义容器运行环境，将函数构建成镜像发布到阿里云镜像仓库中，通过HTTP协议和函数计算系统交互。更多详细介绍可参考文档[Custom Container简介](https://help.aliyun.com/document_detail/179368.html)。使用这种方法，需要开通[阿里云容器镜像服务](https://cr.console.aliyun.com/)。
 
-> ⚠️ 需要注意，该方法也存在使用限制：若您的函数执行内存小于1 GB，则解压前镜像大小不能超过256 MB；若您的函数执行内存不小于1 GB，则解压前镜像大小不能超过1024 MB。
+> ⚠️ 需要注意，该方法也存在一般限制：若您的函数执行内存小于1 GB，则解压前镜像大小不能超过256 MB；若您的函数执行内存不小于1 GB，则解压前镜像大小不能超过1024 MB。有些场景可能会超过这个限制，若有特殊要求，可以在[阿里云智能在线](https://smartservice.console.aliyun.com/)提交工单反应需求。
 
 如果你有容器相关的知识，可以根据自己的项目进行改造，自行编写Dockerfile，再执行后续操作；如果没有的话也没关系，[函数计算custom-container入门示例](https://github.com/awesome-fc/fc-faq/blob/main/docs/%E5%87%BD%E6%95%B0%E8%AE%A1%E7%AE%97custom%E5%92%8Ccustom-container%E5%85%A5%E9%97%A8%E7%A4%BA%E4%BE%8B.md)中展示了一些s工具提供的初始化模板，另外，[fc组件-自定义容器示例](https://github.com/devsapp/fc/tree/main/examples/custom-container-function)也提供了一个小型的示例。接下来，根据以上两个链接中的内容，以部署一个nodejs运行环境的http应用为例进行详细说明。
 


### PR DESCRIPTION
大于100M的部署有3种方法，目前只提供了使用NAS的方法，其余两种方法（layer和custom-container）学习实践后补充。